### PR TITLE
Allow run multiple blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Or install it yourself as:
       end
     end
 
+## Developing
+
+Running tests
+```
+$ rake test
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/yardstick/eventador/fork )

--- a/lib/eventador.rb
+++ b/lib/eventador.rb
@@ -5,21 +5,25 @@ module Eventador
     def method_missing(method, *args, &block)
       false
     end
+
+    def result
+      @result
+    end
   end
 
   def callback(callable, *rest)
-    ret = nil
     @callbacks ||= ::Hash.new do |h, method_name|
       h[method_name] = Class.new(Callback) do
         define_method(method_name) do |&block|
-          ret = block.nil? ? true : block.call(*args)
+          @result = block.nil? ? true : block.call(*args)
         end
         define_method("#{method_name}?") { true }
         define_method(:to_s) { "Callback(#{method_name})" }
       end
     end
-    call(@callbacks[callable].new(rest))
-    ret
+    ret = @callbacks[callable].new(rest)
+    call(ret)
+    ret.result
   end
 end
 

--- a/lib/eventador/version.rb
+++ b/lib/eventador/version.rb
@@ -1,3 +1,3 @@
 module Eventador
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/spec/proc_spec.rb
+++ b/spec/proc_spec.rb
@@ -29,7 +29,7 @@ describe Proc do
     cba(a) do |on|
       on.test do |arg|
         @flag.notify
-        arg.must_equal(a)
+        _(arg).must_equal(a)
       end
     end
   end
@@ -56,6 +56,24 @@ describe Proc do
         a + 1
       end
     end
-    ret.must_equal(2)
+    _(ret).must_equal(2)
+  end
+
+  def cbm(a, &block)
+    block.callback(:add, a)
+
+    block.callback(:block1, a) +
+      block.callback(:block2, a) +
+      block.callback(:block3, a)
+  end
+
+  it 'should allow many callbacks in sequence' do
+    ret = cbm(1) do |on|
+      on.add { @flag.notify }
+      on.block1 { |a| a * 1 }
+      on.block2 { |a| a * 2 }
+      on.block3 { |a| a * 3 }
+    end
+    _(ret).must_equal(6)
   end
 end


### PR DESCRIPTION
# Background

We want to run multiple blocks on the same runtime, eg.

```ruby
def thing(&block)
  amount = 10
  res1 = block.callback(:block1, amount)
  res2 = block.callback(:block2, amount)
  res3 = block.callback(:block3, amount)

  res1 + res2 + res3
end

res = thing do |on|
  on.block1 { |amount| amount * 0.5 }
  on.block2 { |amount| amount * 0.3 }
  on.block3 { |amount| amount * 0.2 }
end
```

# Primary/Major Changes

Allow multiple block callbacks